### PR TITLE
WIP: Fix for crashes when QSPI mode isn't correctly detected

### DIFF
--- a/SPIFlashAnalyzer.py
+++ b/SPIFlashAnalyzer.py
@@ -7,12 +7,17 @@ import struct
 
 # value is dummy clocks
 CONTINUE_COMMANDS = {
+    0x6b: 8,
     0xe7: 2,
     0xeb: 4,
 }
 
 DATA_COMMANDS = {0x03: "Read",
                  0x0b: "Fast Read",
+                 0x5b: "Read SFDP",
+                 0x6b: "Quad-Output Fast Read",
+                 0x9e: "Read JEDEC ID",
+                 0x9f: "Read JEDEC ID",
                  0xe7: "Quad Word Read",
                  0xeb: "Quad Read",
                  0x02: "Page Program",

--- a/SPIFlashAnalyzer.py
+++ b/SPIFlashAnalyzer.py
@@ -120,6 +120,10 @@ class SPIFlash(HighLevelAnalyzer):
                     self._command = 0
                     self._quad_start = None
                     self._dummy = 0
+
+                    # Zero the data buffers to prevent issues with odd lengths of transactions if QSPI mode isn't detected properly.
+                    self._mosi_out = 0
+                    self._miso_in = 0
                 else:
                     self._clock_count = 8
                     f = FakeFrame("result")


### PR DESCRIPTION
This fixes the issues described in #2.

Still marked as WIP right now, due to some slight complexity in handling the `0x6b/Quad-Output Fast Read` command from a Micron Flash. Specifically, despite it being a QSPI command, the address is sent using 'normal' SPI, which means that the analyzer needs to read the address normally, and then switch to quad-decode.