### PR TITLE
Fix frame timing issue causing invalid begin time error

### DIFF
--- a/SPIFlashAnalyzer.py
+++ b/SPIFlashAnalyzer.py
@@ -299,7 +299,7 @@ class SPIFlash(HighLevelAnalyzer):
                                           self._start_time,
                                           fake_frame.end_time,
                                           frame_data)
-                self._start_time = fake_frame.start_time
+                self._start_time = fake_frame.end_time
             if self.decode_level == 'Only Data' and frame_type == "control_command":
                 continue
             if self.decode_level == 'Only Errors' and frame_type != "error":


### PR DESCRIPTION
Fixes #11 - Changed self._start_time to use fake_frame.end_time instead of fake_frame.start_time to ensure each frame begins after the previous frame ends.